### PR TITLE
Switch submodule from ssh to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test/livr"]
 	path = test/livr
-	url = git@github.com:koorchik/LIVR.git
+	url = https://github.com/koorchik/LIVR.git


### PR DESCRIPTION
This change does not affect the code, but it allows you to "go get" or "dep" without the need to register the ssh-key in the github. Without this I was getting errors:
``
go get github.com/k33nice/go-livr
``
``
Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:koorchik/LIVR.git' into submodule path '/Users/pavel.boev/go/src/github.com/k33nice/go-livr/test/livr' failed
Failed to clone 'test/livr' a second time, aborting
package github.com/k33nice/go-livr: exit status 1
``